### PR TITLE
New administrator should have no sections access role

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,10 +58,6 @@
         "analyse": [
             "vendor/bin/phpstan.phar analyse -c phpstan.neon -l max src/",
             "vendor/bin/ecs check src/ spec/"
-        ],
-        "post-install-cmd": [
-            "bin/console sylius:fixtures:load default_administration_role -n",
-            "bin/console sylius-rbac:normalize-administrators"
         ]
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
             "vendor/bin/ecs check src/ spec/"
         ],
         "post-install-cmd": [
-            "bin/console sylius:fixtures:load default_administration_role -n"
+            "bin/console sylius:fixtures:load default_administration_role -n",
+            "bin/console sylius-rbac:normalize-administrators"
         ]
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,9 @@
         "analyse": [
             "vendor/bin/phpstan.phar analyse -c phpstan.neon -l max src/",
             "vendor/bin/ecs check src/ spec/"
+        ],
+        "post-install-cmd": [
+            "bin/console sylius:fixtures:load default_administration_role -n"
         ]
     },
     "extra": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,4 +12,5 @@ parameters:
 
     ignoreErrors:
         - '/Parameter #1 $configuration of method Symfony\Component\DependencyInjection\Extension\Extension::processConfiguration() expects Symfony\Component\Config\Definition\ConfigurationInterface, Symfony\Component\Config\Definition\ConfigurationInterface|null given./'
+        - '/Cannot call method arrayNode() on Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface|null./'
         - '/Call to an undefined method Sylius\\Component\\Core\\Model\\AdminUserInterface/'

--- a/src/Cli/InstallPluginCommand.php
+++ b/src/Cli/InstallPluginCommand.php
@@ -7,6 +7,7 @@ namespace Sylius\RbacPlugin\Cli;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -15,7 +16,18 @@ final class InstallPluginCommand extends Command
     /** @var array */
     private $commands = [
         [
-            'command' => 'grant-access',
+            'command' => 'sylius:fixtures:load',
+            'message' => 'Loads default no sections access role',
+            'parameters' => [
+                'suite' => 'default_administration_role'
+            ],
+        ],
+        [
+            'command' => 'sylius-rbac:normalize-administrators',
+            'message' => 'Assigns new, default role to all administrators in the system',
+        ],
+        [
+            'command' => 'sylius-rbac:grant-access',
             'message' => 'Grants access to given sections to specified administrator',
             'parameters' => [
                 'roleName' => 'Configurator',
@@ -42,13 +54,21 @@ final class InstallPluginCommand extends Command
                 $outputStyle->newLine();
                 $outputStyle->section($this->getCommandMessage($step, $command['message']));
 
+                if (array_key_exists('parameters', $command)){
+                    $input = new ArrayInput($command['parameters']);
+                } else {
+                    $input = new ArrayInput([]);
+                }
+
+                $input->setInteractive(false);
+
                 $this->getApplication()
-                    ->find('sylius-rbac:' . $command['command'])
-                    ->run(new ArrayInput($command['parameters']), $output)
+                    ->find($command['command'])
+                    ->run($input, $output)
                 ;
             } catch (\Exception $exception) {
                 $outputStyle->newLine(2);
-                $outputStyle->warning('RBAC has been installed, but some error occurred.');
+                $outputStyle->warning($exception->getMessage());
 
                 return;
             }

--- a/src/Cli/InstallPluginCommand.php
+++ b/src/Cli/InstallPluginCommand.php
@@ -7,7 +7,6 @@ namespace Sylius\RbacPlugin\Cli;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -19,12 +18,15 @@ final class InstallPluginCommand extends Command
             'command' => 'sylius:fixtures:load',
             'message' => 'Loads default no sections access role',
             'parameters' => [
-                'suite' => 'default_administration_role'
+                'suite' => 'default_administration_role',
             ],
+            'interactive' => false,
         ],
         [
             'command' => 'sylius-rbac:normalize-administrators',
             'message' => 'Assigns new, default role to all administrators in the system',
+            'parameters' => [],
+            'interactive' => false,
         ],
         [
             'command' => 'sylius-rbac:grant-access',
@@ -33,6 +35,7 @@ final class InstallPluginCommand extends Command
                 'roleName' => 'Configurator',
                 'sections' => ['configuration', 'rbac'],
             ],
+            'interactive' => true,
         ],
     ];
 
@@ -54,13 +57,8 @@ final class InstallPluginCommand extends Command
                 $outputStyle->newLine();
                 $outputStyle->section($this->getCommandMessage($step, $command['message']));
 
-                if (array_key_exists('parameters', $command)){
-                    $input = new ArrayInput($command['parameters']);
-                } else {
-                    $input = new ArrayInput([]);
-                }
-
-                $input->setInteractive(false);
+                $input = new ArrayInput($command['parameters']);
+                $input->setInteractive($command['interactive']);
 
                 $this->getApplication()
                     ->find($command['command'])

--- a/src/Cli/NormalizeExistingAdministratorsCommand.php
+++ b/src/Cli/NormalizeExistingAdministratorsCommand.php
@@ -18,7 +18,7 @@ final class NormalizeExistingAdministratorsCommand extends Command
     private $administratorRepository;
 
     /** @var RepositoryInterface */
-    private $administratorRoleRepository;
+    private $administrationRoleRepository;
 
     /** @var ObjectManager */
     private $objectManager;
@@ -31,7 +31,7 @@ final class NormalizeExistingAdministratorsCommand extends Command
         parent::__construct('sylius-rbac:normalize-administrators');
 
         $this->administratorRepository = $administratorRepository;
-        $this->administratorRoleRepository = $administratorRoleRepository;
+        $this->administrationRoleRepository = $administratorRoleRepository;
         $this->objectManager = $objectManager;
     }
 
@@ -43,7 +43,14 @@ final class NormalizeExistingAdministratorsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
         /** @var AdministrationRoleInterface|null $noSectionsAccessRole */
-        $noSectionsAccessRole = $this->administratorRoleRepository->findOneBy(['name' => 'No sections access']);
+        $noSectionsAccessRole = null;
+
+        /** @var AdministrationRoleInterface $administrationRole */
+        foreach ($this->administrationRoleRepository->findAll() as $administrationRole) {
+            if (empty($administrationRole->getPermissions())) {
+                $noSectionsAccessRole = $administrationRole;
+            }
+        }
 
         if (null === $noSectionsAccessRole) {
             $output->writeln('There is no role with no access to any section. Aborting.');
@@ -51,7 +58,6 @@ final class NormalizeExistingAdministratorsCommand extends Command
             return;
         }
 
-        /** @var array $administrators */
         $administrators = $this->administratorRepository->findAll();
 
         /** @var AdminUserInterface $administrator */

--- a/src/Cli/NormalizeExistingAdministratorsCommand.php
+++ b/src/Cli/NormalizeExistingAdministratorsCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RbacPlugin\Cli;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\RbacPlugin\Entity\AdministrationRoleInterface;
+use Sylius\RbacPlugin\Entity\AdminUserInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class NormalizeExistingAdministratorsCommand extends Command
+{
+    /** @var RepositoryInterface */
+    private $administratorRepository;
+
+    /** @var RepositoryInterface */
+    private $administratorRoleRepository;
+
+    /** @var ObjectManager */
+    private $objectManager;
+
+    public function __construct(
+        RepositoryInterface $administratorRepository,
+        RepositoryInterface $administratorRoleRepository,
+        ObjectManager $objectManager
+    ) {
+        parent::__construct('sylius-rbac:normalize-administrators');
+
+        $this->administratorRepository = $administratorRepository;
+        $this->administratorRoleRepository = $administratorRoleRepository;
+        $this->objectManager = $objectManager;
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Assign no sections access role to all administrators in the database');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): void
+    {
+        /** @var AdministrationRoleInterface|null $noSectionsAccessRole */
+        $noSectionsAccessRole = $this->administratorRoleRepository->findOneBy(['permissions' => json_encode([])]);
+
+        if (null === $noSectionsAccessRole) {
+            $output->writeln('There is no role with no access to any section. Aborting.');
+            return;
+        }
+
+        /** @var array $administrators */
+        $administrators = $this->administratorRepository->findAll();
+
+        /** @var AdminUserInterface $administrator */
+        foreach ($administrators as $administrator) {
+            $administrator->setAdministrationRole($noSectionsAccessRole);
+        }
+
+        $this->objectManager->flush();
+    }
+}

--- a/src/Cli/NormalizeExistingAdministratorsCommand.php
+++ b/src/Cli/NormalizeExistingAdministratorsCommand.php
@@ -6,8 +6,8 @@ namespace Sylius\RbacPlugin\Cli;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\RbacPlugin\Entity\AdministrationRoleAwareInterface;
 use Sylius\RbacPlugin\Entity\AdministrationRoleInterface;
-use Sylius\RbacPlugin\Entity\AdminUserInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -60,7 +60,7 @@ final class NormalizeExistingAdministratorsCommand extends Command
 
         $administrators = $this->administratorRepository->findAll();
 
-        /** @var AdminUserInterface $administrator */
+        /** @var AdministrationRoleAwareInterface $administrator */
         foreach ($administrators as $administrator) {
             $administrator->setAdministrationRole($noSectionsAccessRole);
         }

--- a/src/Cli/NormalizeExistingAdministratorsCommand.php
+++ b/src/Cli/NormalizeExistingAdministratorsCommand.php
@@ -43,7 +43,7 @@ final class NormalizeExistingAdministratorsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
         /** @var AdministrationRoleInterface|null $noSectionsAccessRole */
-        $noSectionsAccessRole = $this->administratorRoleRepository->findOneBy(['permissions' => json_encode([])]);
+        $noSectionsAccessRole = $this->administratorRoleRepository->findOneBy(['name' => 'No sections access']);
 
         if (null === $noSectionsAccessRole) {
             $output->writeln('There is no role with no access to any section. Aborting.');

--- a/src/Cli/NormalizeExistingAdministratorsCommand.php
+++ b/src/Cli/NormalizeExistingAdministratorsCommand.php
@@ -47,6 +47,7 @@ final class NormalizeExistingAdministratorsCommand extends Command
 
         if (null === $noSectionsAccessRole) {
             $output->writeln('There is no role with no access to any section. Aborting.');
+
             return;
         }
 

--- a/src/Entity/AdministrationRoleTrait.php
+++ b/src/Entity/AdministrationRoleTrait.php
@@ -11,7 +11,7 @@ trait AdministrationRoleTrait
 {
     /**
      * @ManyToOne(targetEntity="Sylius\RbacPlugin\Entity\AdministrationRole")
-     * @JoinColumn(name="administration_role_id", referencedColumnName="id")
+     * @JoinColumn(name="administrationRole_id", referencedColumnName="id")
      *
      * @var AdministrationRoleInterface|null
      */

--- a/src/Fixture/AdministrationRoleFixture.php
+++ b/src/Fixture/AdministrationRoleFixture.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RbacPlugin\Fixture;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
+use Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Sylius\RbacPlugin\Access\Model\OperationType;
+use Sylius\RbacPlugin\Entity\AdministrationRoleInterface;
+use Sylius\RbacPlugin\Model\Permission;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+
+final class AdministrationRoleFixture extends AbstractFixture implements FixtureInterface
+{
+    /** @var FactoryInterface */
+    private $administrationRoleFactory;
+
+    /** @var ObjectManager */
+    private $administrationRoleManager;
+
+    public function __construct(FactoryInterface $administrationRoleFactory, ObjectManager $administrationRoleManager)
+    {
+        $this->administrationRoleFactory = $administrationRoleFactory;
+        $this->administrationRoleManager = $administrationRoleManager;
+    }
+
+    public function getName(): string
+    {
+        return 'administration_role';
+    }
+
+    public function load(array $options): void
+    {
+        /** @var AdministrationRoleInterface $administrationRole */
+        $administrationRole = $this->administrationRoleFactory->createNew();
+
+        $administrationRole->setName($options['administration_role_name']);
+
+        foreach ($options['permissions'] as $permissionName) {
+            $administrationRole
+                ->addPermission(Permission::ofType($permissionName, [OperationType::READ, OperationType::WRITE]))
+            ;
+        }
+
+        $this->administrationRoleManager->persist($administrationRole);
+        $this->administrationRoleManager->flush();
+    }
+
+    protected function configureOptionsNode(ArrayNodeDefinition $optionsNode): void
+    {
+        $optionsNode
+            ->children()
+                ->scalarNode('administration_role_name')
+                    ->cannotBeEmpty()
+                ->end()
+                ->arrayNode('permissions')
+                    ->addDefaultsIfNotSet()
+                ->end()
+            ->end()
+        ->end();
+    }
+}

--- a/src/Fixture/AdministrationRoleFixture.php
+++ b/src/Fixture/AdministrationRoleFixture.php
@@ -37,7 +37,7 @@ final class AdministrationRoleFixture extends AbstractFixture implements Fixture
         /** @var AdministrationRoleInterface $administrationRole */
         $administrationRole = $this->administrationRoleFactory->createNew();
 
-        $administrationRole->setName($options['administration_role_name']);
+        $administrationRole->setName($options['name']);
 
         foreach ($options['permissions'] as $permissionName) {
             $administrationRole
@@ -53,7 +53,7 @@ final class AdministrationRoleFixture extends AbstractFixture implements Fixture
     {
         $optionsNode
             ->children()
-                ->scalarNode('administration_role_name')
+                ->scalarNode('name')
                     ->cannotBeEmpty()
                 ->end()
                 ->arrayNode('permissions')

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -8,7 +8,7 @@ sylius_fixtures:
             fixtures:
                 administration_role:
                     options:
-                        administration_role_name: 'No sections access'
+                        name: 'No sections access'
             listeners:
                 logger: ~
 

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -2,6 +2,16 @@ prooph_service_bus:
     command_buses:
         sylius_rbac_command_bus: ~
 
+sylius_fixtures:
+    suites:
+        default_administration_role:
+            fixtures:
+                administration_role:
+                    options:
+                        administration_role_name: 'No sections access'
+            listeners:
+                logger: ~
+
 sylius_resource:
     resources:
         sylius_rbac.administration_role:

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -72,5 +72,15 @@
         <service id="Sylius\RbacPlugin\Cli\InstallPluginCommand">
             <tag name="console.command" command="sylius-rbac:install-plugin" />
         </service>
+
+        <service
+                id="sylius.rbac_plugin.fixture.administration_role_fixture"
+                class="Sylius\RbacPlugin\Fixture\AdministrationRoleFixture"
+                public="true"
+        >
+            <argument type="service" id="sylius_rbac.custom_factory.administration_role" />
+            <argument type="service" id="doctrine.orm.entity_manager" />
+            <tag name="sylius_fixtures.fixture"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -73,6 +73,13 @@
             <tag name="console.command" command="sylius-rbac:install-plugin" />
         </service>
 
+        <service id="Sylius\RbacPlugin\Cli\NormalizeExistingAdministratorsCommand">
+            <argument type="service" id="sylius.repository.admin_user" />
+            <argument type="service" id="sylius_rbac.repository.administration_role" />
+            <argument type="service" id="doctrine.orm.entity_manager" />
+            <tag name="console.command" command="sylius-rbac:normalize-administrators" />
+        </service>
+
         <service
                 id="sylius.rbac_plugin.fixture.administration_role_fixture"
                 class="Sylius\RbacPlugin\Fixture\AdministrationRoleFixture"

--- a/tests/Application/config/packages/_sylius.yaml
+++ b/tests/Application/config/packages/_sylius.yaml
@@ -71,6 +71,6 @@ sylius_fixtures:
             fixtures:
                 administration_role:
                     options:
-                        administration_role_name: 'No sections access'
+                        name: 'No sections access'
             listeners:
                 logger: ~

--- a/tests/Application/config/packages/_sylius.yaml
+++ b/tests/Application/config/packages/_sylius.yaml
@@ -64,3 +64,13 @@ sylius_grid:
                     sortable: true
                     options:
                         template: '@SyliusRbacPlugin/AdministrationRole/Grid/Field/administrationRole.html.twig'
+
+sylius_fixtures:
+    suites:
+        default_administration_role:
+            fixtures:
+                administration_role:
+                    options:
+                        administration_role_name: 'No sections access'
+            listeners:
+                logger: ~


### PR DESCRIPTION
<img width="1081" alt="screenshot 2018-12-02 at 13 01 13" src="https://user-images.githubusercontent.com/22262296/49339488-ca70fc00-f632-11e8-8589-6b849dae8621.png">


As a result, the default role with no access to any section is added to the database, assigned to each administrator and then the root administrator is chosen by the user.

Administration panel index page after logging in with No sections access permission:

<img width="1440" alt="screenshot 2018-12-02 at 13 18 38" src="https://user-images.githubusercontent.com/22262296/49339617-0311d500-f635-11e8-8d78-2342127cd12d.png">

TBD: Create landing page that will remove data from dashboard.