### PR TITLE
Adding verbosity to second step in installation

### DIFF
--- a/src/Cli/NormalizeExistingAdministratorsCommand.php
+++ b/src/Cli/NormalizeExistingAdministratorsCommand.php
@@ -60,6 +60,14 @@ final class NormalizeExistingAdministratorsCommand extends Command
 
         $administrators = $this->administratorRepository->findAll();
 
+        if (count($administrators) === 0) {
+            $output->writeln('No administrators found. No migration needed.');
+
+            return;
+        }
+
+        $output->writeln(sprintf('Found %d administrator(s). Migrating them.', count($administrators)));
+
         /** @var AdministrationRoleAwareInterface $administrator */
         foreach ($administrators as $administrator) {
             $administrator->setAdministrationRole($noSectionsAccessRole);


### PR DESCRIPTION
I know "No output is good output" but this only goes for programmers. :D And it's always good to see that the computer is doing something.