### PR TITLE
Decrease remove menu listener priority

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -57,7 +57,7 @@
             <argument type="service" id="security.token_storage" />
             <argument type="service" id="Sylius\RbacPlugin\Access\Checker\AdministratorAccessCheckerInterface" />
             <argument>%sylius_rbac.configuration%</argument>
-            <tag name="kernel.event_listener" event="sylius.menu.admin.main" method="removeInaccessibleAdminMenuParts" />
+            <tag name="kernel.event_listener" event="sylius.menu.admin.main" method="removeInaccessibleAdminMenuParts" priority="-256" />
         </service>
 
         <service id="Sylius\RbacPlugin\Normalizer\AdministrationRolePermissionNormalizer" />


### PR DESCRIPTION
We have to decrease the priority to be the last menu listener so we can remove all available menu.